### PR TITLE
Dynamic loading of client preference chemistry operators and drivers

### DIFF
--- a/qiskit_acqua_chemistry/core/__init__.py
+++ b/qiskit_acqua_chemistry/core/__init__.py
@@ -17,18 +17,20 @@
 
 from .chemistry_operator import ChemistryOperator
 from .hamiltonian import Hamiltonian
-from ._discover_chemoperator import (register_chemistry_operator,
-                              deregister_chemistry_operator,
-                              get_chemistry_operator_class,
-                              get_chemistry_operator_instance,
-                              get_chemistry_operator_configuration,
-                              local_chemistry_operators)
+from ._discover_chemoperator import (refresh_operators,
+                                     register_chemistry_operator,
+                                     deregister_chemistry_operator,
+                                     get_chemistry_operator_class,
+                                     get_chemistry_operator_instance,
+                                     get_chemistry_operator_configuration,
+                                     local_chemistry_operators)
 
 __all__ = ['ChemistryOperator',
            'Hamiltonian',
-          'register_chemistry_operator',
-          'deregister_chemistry_operator',
-          'get_chemistry_operator_class',
-          'get_chemistry_operator_instance',
-          'get_chemistry_operator_configuration',
-          'local_chemistry_operators']
+           'refresh_operators',
+           'register_chemistry_operator',
+           'deregister_chemistry_operator',
+           'get_chemistry_operator_class',
+           'get_chemistry_operator_instance',
+           'get_chemistry_operator_configuration',
+           'local_chemistry_operators']

--- a/qiskit_acqua_chemistry/core/_discover_chemoperator.py
+++ b/qiskit_acqua_chemistry/core/_discover_chemoperator.py
@@ -26,12 +26,13 @@ import inspect
 from collections import namedtuple
 from .chemistry_operator import ChemistryOperator
 from qiskit_acqua_chemistry import ACQUAChemistryError
+from qiskit_acqua_chemistry.preferences import Preferences
 import logging
 import sys
 
 logger = logging.getLogger(__name__)
 
-_NAMES_TO_EXCLUDE = ['_discover_chemoperator',]
+_NAMES_TO_EXCLUDE = ['_discover_chemoperator']
 
 _FOLDERS_TO_EXCLUDE = ['__pycache__']
 
@@ -41,12 +42,85 @@ _REGISTERED_CHEMISTRY_OPERATORS = {}
 
 _DISCOVERED = False
 
+def refresh_operators():
+    """
+    Attempts to rediscover all operator modules
+    """
+    global _REGISTERED_CHEMISTRY_OPERATORS
+    _REGISTERED_CHEMISTRY_OPERATORS = {}
+    global _DISCOVERED
+    _DISCOVERED = True
+    discover_local_chemistry_operators() 
+    discover_preferences_chemistry_operators()
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("Found: chemistry operators {} ".format(local_chemistry_operators()))
+
 def _discover_on_demand():
     """
-    Attempts to discover input modules, if not already discovered
+    Attempts to discover operator modules, if not already discovered
     """
+    global _DISCOVERED
     if not _DISCOVERED:
-        discover_local_chemistry_operators()
+        _DISCOVERED = True
+        discover_local_chemistry_operators() 
+        discover_preferences_chemistry_operators()
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("Found: chemistry operators {} ".format(local_chemistry_operators()))
+
+def discover_preferences_chemistry_operators():
+    """
+    Discovers the chemistry operators on the directory and subdirectories of the preferences package
+    and attempts to register them. Chem.Operator modules should subclass ChemistryOperator Base class.
+    """
+    preferences = Preferences()
+    packages = preferences.get_packages(Preferences.PACKAGE_TYPE_OPERATOR,[])
+    for package in packages:
+        try:
+            mod = importlib.import_module(package)
+            if mod is not None:
+                _discover_local_chemistry_operators(os.path.dirname(mod.__file__),
+                                           os.path.splitext(mod.__name__)[0],
+                                           names_to_exclude=['__main__'],
+                                           folders_to_exclude= ['__pycache__'])
+            else:
+                # Ignore package that could not be initialized.
+                logger.debug('Failed to import package {}'.format(package))
+        except Exception as e:
+            # Ignore package that could not be initialized.
+            logger.debug('Failed to load package {} error {}'.format(package, str(e)))
+        
+def _discover_local_chemistry_operators(directory,
+                                        parentname,
+                                        names_to_exclude=_NAMES_TO_EXCLUDE,
+                                        folders_to_exclude=_FOLDERS_TO_EXCLUDE):
+        for _, name, ispackage in pkgutil.iter_modules([directory]):
+            if ispackage:
+                continue
+            
+            # Iterate through the modules
+            if name not in names_to_exclude:  # skip those modules
+                try:
+                    fullname = parentname + '.' + name
+                    modspec = importlib.util.find_spec(fullname)
+                    mod = importlib.util.module_from_spec(modspec)
+                    modspec.loader.exec_module(mod)
+                    for _, cls in inspect.getmembers(mod, inspect.isclass):
+                        # Iterate through the classes defined on the module.
+                        try:
+                            if cls.__module__ == modspec.name and issubclass(cls, ChemistryOperator):
+                                register_chemistry_operator(cls)
+                                importlib.import_module(fullname)
+                        except Exception as e:
+                            # Ignore operator that could not be initialized.
+                            logger.debug('Failed to load {} error {}'.format(fullname, str(e)))
+                except Exception as e:
+                    # Ignore operator that could not be initialized.
+                    logger.debug('Failed to load {} error {}'.format(fullname, str(e)))
+                    
+        for item  in os.listdir(directory):
+            fullpath = os.path.join(directory,item)
+            if item not in folders_to_exclude and not item.endswith('dSYM') and os.path.isdir(fullpath):
+                _discover_local_chemistry_operators(fullpath,parentname + '.' + item,names_to_exclude,folders_to_exclude)
 
 def discover_local_chemistry_operators(directory=os.path.dirname(__file__),
                            parentname=os.path.splitext(__name__)[0]):
@@ -67,35 +141,7 @@ def discover_local_chemistry_operators(directory=os.path.dirname(__file__),
                 syspath += _get_sys_path(fullpath)
                 
         return syspath
-
-    def _discover_local_chemistry_operators(directory,parentname):
-        for _, name, ispackage in pkgutil.iter_modules([directory]):
-            if ispackage:
-                continue
-            
-            # Iterate through the modules
-            if name not in _NAMES_TO_EXCLUDE:  # skip those modules
-                try:
-                    fullname = parentname + '.' + name
-                    modspec = importlib.util.find_spec(fullname)
-                    mod = importlib.util.module_from_spec(modspec)
-                    modspec.loader.exec_module(mod)
-                    for _, cls in inspect.getmembers(mod, inspect.isclass):
-                        # Iterate through the classes defined on the module.
-                        if cls.__module__ == modspec.name and issubclass(cls, ChemistryOperator):
-                            register_chemistry_operator(cls)
-                            importlib.import_module(fullname)
-                except Exception as e:
-                    # Ignore algorithms that could not be initialized.
-                    logger.debug('Failed to load {} error {}'.format(fullname, str(e)))
-                    
-        for item  in os.listdir(directory):
-            fullpath = os.path.join(directory,item)
-            if item not in _FOLDERS_TO_EXCLUDE and not item.endswith('dSYM') and os.path.isdir(fullpath):
-                _discover_local_chemistry_operators(fullpath,parentname + '.' + item)
     
-    global _DISCOVERED
-    _DISCOVERED = True
     syspath_save = sys.path
     sys.path = _get_sys_path(directory) + sys.path
     try:

--- a/qiskit_acqua_chemistry/drivers/configurationmanager.py
+++ b/qiskit_acqua_chemistry/drivers/configurationmanager.py
@@ -25,6 +25,7 @@ import importlib
 import inspect
 import copy
 from ._basedriver import BaseDriver
+from qiskit_acqua_chemistry.preferences import Preferences
 
 logger = logging.getLogger(__name__)
 
@@ -175,13 +176,43 @@ class ConfigurationManager(object):
             """Return names"""
             self._discover_on_demand()
             return list(self._registration.keys())
-             
+        
+        def refresh_drivers(self):
+            """
+            Attempts to rediscover all drivers
+            """
+            self._discovered = False
+            self._discover_on_demand()
+                
         def _discover_on_demand(self):
             if not self._discovered:
+                self._discovered = True
                 self._registration = OrderedDict()
                 self.discover_configurations(os.path.dirname(__file__),
                                              os.path.splitext(__name__)[0])
-                self._discovered = True
+                self.discover_preferences_configurations()
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug("Found: chemistry driver names {} ".format(self.module_names))
+                    
+        def discover_preferences_configurations(self):
+            """
+            Discovers the configuration.json files on the directory and subdirectories of the preferences package
+            and attempts to load  them.
+            """
+            preferences = Preferences()
+            packages = preferences.get_packages(Preferences.PACKAGE_TYPE_CHEMISTRY,[])
+            for package in packages:
+                    try:
+                        mod = importlib.import_module(package)
+                        if mod is not None:
+                            self.discover_configurations(os.path.dirname(mod.__file__),
+                                                       os.path.splitext(mod.__name__)[0])
+                        else:
+                            # Ignore package that could not be initialized.
+                            logger.debug('Failed to import package {}'.format(package))
+                    except Exception as e:
+                        # Ignore package that could not be initialized.
+                        logger.debug('Failed to load package {} error {}'.format(package, str(e)))
          
         def discover_configurations(self,directory,parentname):
             """
@@ -202,17 +233,16 @@ class ConfigurationManager(object):
                             jsonschema.validate(json_dict,self.schema)
                             module = json_dict['module']
                             if not os.path.isfile(os.path.join(directory,module + '.py')):
-                                raise LookupError('Module {} not found.'.format(module))
-                            
-                            self._registration[json_dict['name']] = { 
-                                        'path': directory,
-                                        'fullname': parentname + '.' + module,
-                                        'configuration':json_dict,
-                                        'class': None
-                                    }
+                                logger.debug('Module {} not found.'.format(module))
+                            else:
+                                self._registration[json_dict['name']] = { 
+                                            'path': directory,
+                                            'fullname': parentname + '.' + module,
+                                            'configuration':json_dict,
+                                            'class': None
+                                        }
                         except Exception as e:
-                            logger.info('Configuration error: {}'.format(str(e)))
-                            raise
+                            logger.debug('Configuration error: {}'.format(str(e)))
                         
                     continue
                 

--- a/qiskit_acqua_chemistry/preferences.py
+++ b/qiskit_acqua_chemistry/preferences.py
@@ -20,9 +20,12 @@ import json
 import re
 import copy
 import qiskit_acqua
+from qiskit_acqua_chemistry import ACQUAChemistryError
 
 class Preferences(object):
    
+    PACKAGE_TYPE_CHEMISTRY = 'chemistry'
+    PACKAGE_TYPE_OPERATOR = 'operators'
     _FILENAME = '.qiskit_acqua_chemistry'
     _VERSION = '1.0'
     _QCONFIG_NAME = 'Qconfig'
@@ -34,6 +37,7 @@ class Preferences(object):
         self._preferences = { 
                 'version' : Preferences._VERSION
         }
+        self._packages_changed = False
         self._qconfig_changed = False
         self._logging_config_changed = False
         self._token = None
@@ -99,10 +103,11 @@ class Preferences(object):
             if qconfig is not None:
                 qiskit_acqua.set_qconfig(qconfig)
         
-        if self._logging_config_changed:
+        if self._logging_config_changed or self._packages_changed:
             with open(self._filepath, 'w') as fp:
                 json.dump(self._preferences, fp, sort_keys=True, indent=4) 
             self._logging_config_changed = False
+            self._packages_changed = False
         
     def get_version(self):
         if 'version' in self._preferences:
@@ -193,6 +198,86 @@ class Preferences(object):
         if self._proxy_urls != proxy_urls:
             self._qconfig_changed = True
             self._proxy_urls = proxy_urls
+            
+    def get_packages(self, package_type, default_value=None):
+        if package_type is not None and isinstance(package_type,str) and \
+            'packages' in self._preferences and self._preferences['packages'] is not None and \
+            package_type in self._preferences['packages'] and self._preferences['packages'][package_type] is not None:
+            return copy.deepcopy(self._preferences['packages'][package_type])
+
+        return default_value
+    
+    def add_package(self, package_type, package):
+        if package_type is not None and isinstance(package_type,str) and package is not None and isinstance(package,str): 
+            if package_type != Preferences.PACKAGE_TYPE_CHEMISTRY and package_type != Preferences.PACKAGE_TYPE_OPERATOR:
+                raise ACQUAChemistryError('Invalid package type {}'.format(package_type))
+                
+            packages = self.get_packages(package_type,[])
+            if package not in packages:
+                packages.append(package)
+                if 'packages' in self._preferences and self._preferences['packages'] is not None:
+                    self._preferences['packages'][package_type] = packages
+                else:
+                    self._preferences['packages'] = { package_type : packages }
+                    
+                self._packages_changed = True
+                return True
+            
+        return False
+    
+    def change_package(self, package_type, old_package, new_package):
+        if package_type is not None and isinstance(package_type,str) and \
+            old_package is not None and isinstance(old_package,str) and \
+            new_package is not None and isinstance(new_package,str): 
+            if package_type != Preferences.PACKAGE_TYPE_CHEMISTRY and package_type != Preferences.PACKAGE_TYPE_OPERATOR:
+                raise ACQUAChemistryError('Invalid package type {}'.format(package_type))
+                
+            packages = self.get_packages(package_type,[])
+            for index,package in enumerate(packages):
+                if package == old_package:
+                    packages[index] = new_package
+                    if 'packages' in self._preferences and self._preferences['packages'] is not None:
+                        self._preferences['packages'][package_type] = packages
+                    else:
+                        self._preferences['packages'] = { package_type : packages }
+                    
+                    self._packages_changed = True
+                    return True
+            
+        return False
+                
+    def remove_package(self, package_type, package):
+        if package_type is not None and isinstance(package_type,str) and package is not None and isinstance(package,str): 
+            packages = self.get_packages(package_type,[])
+            if package in packages:
+                packages.remove(package)
+                if 'packages' in self._preferences and self._preferences['packages'] is not None:
+                    self._preferences['packages'][package_type] = packages
+                else:
+                    self._preferences['packages'] = { package_type : packages }
+                        
+                self._packages_changed = True
+                return True
+            
+        return False
+    
+    def set_packages(self, package_type, packages):
+        if package_type is not None and isinstance(package_type,str): 
+            if package_type != Preferences.PACKAGE_TYPE_CHEMISTRY and package_type != Preferences.PACKAGE_TYPE_OPERATOR:
+                raise ACQUAChemistryError('Invalid package type {}'.format(package_type))
+                
+            if 'packages' in self._preferences and self._preferences['packages'] is not None:
+                self._preferences['packages'][package_type] = packages
+            else:
+                self._preferences['packages'] = { package_type : packages }
+                    
+            self._packages_changed = True
+            return True
+            
+        return False
+    
+        self._packages_changed = True
+        self._preferences['packages'] = packages
     
     def get_logging_config(self,default_value=None):
         if 'logging_config' in self._preferences:

--- a/qiskit_acqua_chemistry/ui/_preferencesdialog.py
+++ b/qiskit_acqua_chemistry/ui/_preferencesdialog.py
@@ -17,9 +17,14 @@
 
 import tkinter as tk
 import tkinter.ttk as ttk
+from tkinter import font
 from qiskit_acqua_chemistry.ui._dialog import Dialog
 from collections import OrderedDict
+from qiskit_acqua_chemistry.core import refresh_operators
+from qiskit_acqua_chemistry.drivers import ConfigurationManager
 from qiskit_acqua_chemistry.ui._qconfigview import QconfigView
+from qiskit_acqua_chemistry.ui._toolbarview import ToolbarView
+from qiskit_acqua_chemistry.ui._customwidgets import EntryCustom
 from qiskit_acqua_chemistry.preferences import Preferences
 from qiskit_acqua_chemistry.ui._uipreferences import UIPreferences
 from qiskit_acqua_chemistry._logging import get_logger_levels_for_names,build_logging_config,set_logger_config
@@ -41,6 +46,7 @@ class PreferencesDialog(Dialog):
         self._qconfigview = None
         self._levelCombo = None
         self._checkButton = None
+        self._packagesPage = None
         self._populateDefaults = tk.IntVar()
        
     def body(self,parent,options):
@@ -74,12 +80,29 @@ class PreferencesDialog(Dialog):
                                             variable=self._populateDefaults)
         self._checkButton.grid(row=0, column=1,sticky='nsw')
         
+        packagesGroup = ttk.LabelFrame(parent,
+                                     text='Packages',
+                                     padding=(6,6,6,6),
+                                     borderwidth=4,
+                                     relief=tk.GROOVE)
+        packagesGroup.grid(padx=(7,7),pady=6,row=2, column=0,sticky='nsw')
+        packagesGroup.columnconfigure(1,pad=7)
+        
+        frame = ttk.Frame(packagesGroup)
+        frame.grid(row=0, column=0,sticky='nsew')
+        
+        self._packagesPage = PackagesPage(frame,preferences)
+        self._packagesPage.pack(side=tk.TOP,fill=tk.BOTH, expand=tk.TRUE)
+        self._packagesPage.show_add_button(True)
+        self._packagesPage.show_remove_button(self._packagesPage.has_selection())
+        self._packagesPage.show_defaults_button(False)
+        
         loggingGroup = ttk.LabelFrame(parent,
                                      text='Logging Configuration',
                                      padding=(6,6,6,6),
                                      borderwidth=4,
                                      relief=tk.GROOVE)
-        loggingGroup.grid(padx=(7,7),pady=6,row=2, column=0,sticky='nsw')
+        loggingGroup.grid(padx=(7,7),pady=6,row=3, column=0,sticky='nsw')
         loggingGroup.columnconfigure(1,pad=7)
         
         levels = get_logger_levels_for_names(['qiskit_acqua_chemistry','qiskit_acqua'])
@@ -101,8 +124,16 @@ class PreferencesDialog(Dialog):
         return self.entry # initial focus
     
     def validate(self):
+        if not self._qconfigview.validate():
+            self.initial_focus = self._qconfigview.initial_focus
+            return False
+        
+        if not self._packagesPage.validate():
+            self.initial_focus = self._packagesPage.initial_focus
+            return False
+        
         self.initial_focus = self._qconfigview.initial_focus
-        return self._qconfigview.validate()
+        return True
 
     def apply(self):
         try:
@@ -113,6 +144,7 @@ class PreferencesDialog(Dialog):
         
             preferences = Preferences()
             self._qconfigview.apply(preferences)
+            self._packagesPage.apply(preferences)
             preferences.set_logging_config(logging_config)
             preferences.save()
             set_logger_config(logging_config)
@@ -125,3 +157,202 @@ class PreferencesDialog(Dialog):
             self._controller.get_available_backends()
         except Exception as e:
             self.controller.outputview.write_line(str(e))
+
+class PackagesPage(ToolbarView):
+
+    def __init__(self, parent, preferences, **options):
+        super(PackagesPage, self).__init__(parent, **options)
+        size = font.nametofont('TkHeadingFont').actual('size')
+        ttk.Style().configure("PackagesPage.Treeview.Heading", font=(None,size,'bold'))
+        self._tree = ttk.Treeview(self, style='PackagesPage.Treeview', selectmode=tk.BROWSE, height=4,columns=['value'])
+        self._tree.heading('#0', text='Type')
+        self._tree.heading('value',text='Name')
+        self._tree.column('#0',minwidth=0,width=150,stretch=tk.NO)
+        self._tree.column('value',minwidth=0,width=500,stretch=tk.YES)
+        self._tree.bind('<<TreeviewSelect>>', self._on_tree_select)
+        self._tree.bind('<Button-1>', self._on_tree_edit)
+        self.init_widgets(self._tree)
+        
+        self._preferences = Preferences()
+        self._popup_widget = None
+        self.pack(fill=tk.BOTH, expand=tk.TRUE)
+        self.populate()
+        self.initial_focus = self._tree
+        
+    def clear(self):
+        if self._popup_widget is not None and self._popup_widget.winfo_exists():
+            self._popup_widget.destroy()
+            
+        self._popup_widget = None
+        for i in self._tree.get_children():
+            self._tree.delete([i])
+            
+    def populate(self):
+        self.clear()
+        packages = self._preferences.get_packages(Preferences.PACKAGE_TYPE_CHEMISTRY,[])
+        for package in packages:
+            self._populate(Preferences.PACKAGE_TYPE_CHEMISTRY,package)
+            
+        packages = self._preferences.get_packages(Preferences.PACKAGE_TYPE_OPERATOR,[])
+        for package in packages:
+            self._populate(Preferences.PACKAGE_TYPE_OPERATOR,package)
+            
+    def _populate(self,package_type,package):
+        package_type = '' if type is None else str(package_type)
+        package_type = package_type.replace('\r', '\\r').replace('\n', '\\n')
+        package = '' if package is None else str(package)
+        package = package.replace('\r', '\\r').replace('\n', '\\n')
+        self._tree.insert('',tk.END, text=package_type, values=[package])
+            
+    def has_selection(self):
+        return self._tree.selection()
+            
+    def _on_tree_select(self,event):
+        for item in self._tree.selection():
+            self.show_remove_button(True)
+            return
+        
+    def _on_tree_edit(self,event):
+        rowid = self._tree.identify_row(event.y)
+        if not rowid:
+            return
+    
+        column = self._tree.identify_column(event.x)
+        if column == '#1':
+            x,y,width,height = self._tree.bbox(rowid, column)
+            pady = height // 2
+           
+            item = self._tree.identify("item", event.x, event.y)
+            package_type = self._tree.item(item, "text")
+            package = self._tree.item(item,'values')[0]
+            self._popup_widget = PackagePopup(self,
+                                package_type,
+                                self._tree,
+                                package,
+                                state=tk.NORMAL)
+            self._popup_widget.selectAll()
+            self._popup_widget.place(x=x, y=y+pady, anchor=tk.W, width=width)
+        
+    def onadd(self):
+        dialog = PackageComboDialog(self.master,self)
+        dialog.do_init(tk.LEFT)
+        dialog.do_modal()
+        if dialog.result is not None and self._preferences.add_package(dialog.result[0],dialog.result[1]):
+            self.populate()
+            self.show_remove_button(self.has_selection())
+            
+    def onremove(self):
+        for item in self._tree.selection():
+            package_type = self._tree.item(item,'text')
+            package = self._tree.item(item,'values')[0]
+            if self._preferences.remove_package(package_type,package):
+                self.populate()
+                self.show_remove_button(self.has_selection())
+              
+            break
+        
+    def on_package_set(self,package_type,old_package,new_package):
+        new_package = new_package.strip()
+        if len(new_package) == 0:
+            return False
+        
+        if self._preferences.change_package(package_type,old_package,new_package):
+                 self.populate()
+                 self.show_remove_button(self.has_selection()) 
+                 return True
+
+        return False
+    
+    def is_valid(self):
+        return True
+    
+    def validate(self):
+        return True
+        
+    def apply(self,preferences):
+        changed = False
+        packages = self._preferences.get_packages(Preferences.PACKAGE_TYPE_CHEMISTRY,[])
+        if packages != preferences.get_packages(Preferences.PACKAGE_TYPE_CHEMISTRY,[]):
+            preferences.set_packages(Preferences.PACKAGE_TYPE_CHEMISTRY,packages)
+            changed = True
+            
+        packages = self._preferences.get_packages(Preferences.PACKAGE_TYPE_OPERATOR,[])
+        if packages != preferences.get_packages(Preferences.PACKAGE_TYPE_OPERATOR,[]):
+            preferences.set_packages(Preferences.PACKAGE_TYPE_OPERATOR,packages)
+            changed = True
+        
+        if changed:
+            preferences.save()
+            refresh_operators()
+            configuration_mgr = ConfigurationManager()
+            configuration_mgr.refresh_drivers()
+            
+class PackagePopup(EntryCustom):
+
+    def __init__(self, controller,package_type,parent, text, **options):
+        ''' If relwidth is set, then width is ignored '''
+        super(PackagePopup, self).__init__(parent,**options)
+        self._controller = controller
+        self._package_type = package_type
+        self._text = text
+        self.insert(0, self._text) 
+        self.focus_force()
+        self.bind("<Unmap>", self._update_value)
+        self.bind("<FocusOut>", self._update_value)
+        
+    def selectAll(self):
+        self.focus_force()
+        self.selection_range(0, tk.END)
+    
+    def _update_value(self, *ignore):
+        new_text = self.get()
+        valid = True
+        if self._text != new_text:
+            valid = self._controller.on_package_set(self._package_type,self._text,new_text)
+            self._text = new_text
+          
+        if valid:
+            self.destroy()
+        else:
+            self.selectAll() 
+            
+class PackageComboDialog(Dialog):
+    
+    def __init__(self,parent,controller):
+        super(PackageComboDialog, self).__init__(None,parent,"New Package")
+        self._package_type = None
+        self._package = None
+        self._controller = controller
+       
+    def body(self, parent,options):
+        ttk.Label(parent,
+                  text='Type:',
+                  borderwidth=0,
+                  anchor=tk.E).grid(padx=7,pady=6,row=0,sticky='nse')
+        self._package_type = ttk.Combobox(parent,
+                                  exportselection=0,
+                                  state='readonly',
+                                  values=[Preferences.PACKAGE_TYPE_CHEMISTRY,Preferences.PACKAGE_TYPE_OPERATOR])
+        self._package_type.current(0)
+        self._package_type.grid(padx=(0,7),pady=6,row=0, column=1,sticky='nsw')
+        
+        ttk.Label(parent,
+                  text="Package:",
+                  borderwidth=0,
+                  anchor=tk.E).grid(padx=7,pady=6,row=1,sticky='nse')
+        self._package = EntryCustom(parent,state=tk.NORMAL)
+        self._package.grid(padx=(0,7),pady=6,row=1, column=1,sticky='nsw')
+        return self._package_type # initial focus
+    
+    def validate(self):
+        package_type = self._package_type.get()
+        package = self._package.get().strip()
+        if len(package) == 0 or package in self._controller._preferences.get_packages(package_type,[]):
+            self.initial_focus = self._package
+            return False
+                
+        self.initial_focus = self._package_type
+        return True
+
+    def apply(self):
+        self.result = (self._package_type.get(),self._package.get().strip())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
It can be tested by cloning repositories: 
https://github.com/manoelmarques/mock-chemistry-operators
https://github.com/manoelmarques/mock-chemistry-drivers
and running 'pip install -e .' from their root folders.
The installation will add mock_chemistry_operators and mock_chemistry_drivers in the preferences file which can be viewed and changed from the GUI Preferences Pane.
Once installed one can chose the driver 'MockDriver' and the operator 'mockoperator' in the GUI. They will fail if run since there is no implementation.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.